### PR TITLE
#3 [Feat] WeatherUseCase 작성

### DIFF
--- a/WeatherPlan/WeatherPlan/Data/LocationManager.swift
+++ b/WeatherPlan/WeatherPlan/Data/LocationManager.swift
@@ -7,12 +7,13 @@
 
 import CoreLocation
 
-class LocationManager: NSObject {
+class LocationManager: NSObject, LocationInterface {
     private var locationManager: CLLocationManager?
     
-    private var locationUpdateHandler: ((CLLocation) -> ())?
-    
     private var updateState = false
+    
+    /// Location이 Update될 때 실행되는 클로저
+    var locationUpdateHandler: ((CLLocation) -> ())?
     
     var locationAvalible: Bool {
         return locationManager?.authorizationStatus == .authorizedWhenInUse
@@ -22,19 +23,13 @@ class LocationManager: NSObject {
         updateState.toggle()
     }
     
-    /// LocationManager Initializer
-    /// - Parameters:
-    ///   - locationManager: CLLocationManager 객체
-    ///   - locationUpdateHandler: Location이 Update될 때 실행될 클로저
-    init(locationManager: CLLocationManager, locationUpdateHandler: @escaping (CLLocation) -> ()) {
+    override init() {
         super.init()
         
-        self.locationManager = locationManager
-        locationManager.delegate = self
+        self.locationManager = CLLocationManager()
+        self.locationManager?.delegate = self
         
-        self.locationUpdateHandler = locationUpdateHandler
-        
-        locationManager.startUpdatingLocation()
+        self.locationManager?.startUpdatingLocation()
     }
 }
 

--- a/WeatherPlan/WeatherPlan/Data/WeatherManager.swift
+++ b/WeatherPlan/WeatherPlan/Data/WeatherManager.swift
@@ -5,4 +5,17 @@
 //  Created by Yunki on 6/14/24.
 //
 
-import Foundation
+// MARK: - Gureum
+import WeatherKit
+import CoreLocation.CLLocation
+
+class WeatherManager: WeatherInterface {
+    
+    /// fetchWeather(location: CLLocation) -> [WeatherModel]
+    /// - Parameter location: 특정 장소의 위치 정보
+    /// - Returns: 열흘간의 날짜(Date)별 날씨(WeatherCondition) 배열
+    func fetchWeather(location: CLLocation) -> [WeatherModel] {
+        // TODO: - 이 메서드 완성
+        return []
+    }
+}

--- a/WeatherPlan/WeatherPlan/Domain/Entity/WeatherModel.swift
+++ b/WeatherPlan/WeatherPlan/Domain/Entity/WeatherModel.swift
@@ -7,6 +7,17 @@
 
 import Foundation
 
-struct WeatherModel {
+struct WeatherModel: Identifiable {
+    let id: UUID = UUID()
+    let date: Date
+    let weatherCondition: WeatherCondition
     
+    enum WeatherCondition {
+        case rainy
+        case heat
+        case dusty
+        case ultraviolet
+        case windy
+        case sunny
+    }
 }

--- a/WeatherPlan/WeatherPlan/Domain/UseCase/interface/LocationInterface.swift
+++ b/WeatherPlan/WeatherPlan/Domain/UseCase/interface/LocationInterface.swift
@@ -8,5 +8,7 @@
 import CoreLocation.CLLocation
 
 protocol LocationInterface {
-    var location: CLLocation? { get }
+    var locationUpdateHandler:  ((CLLocation) -> ())? { get set }
+    var locationAvalible: Bool { get }
+    func triggerHandler()
 }

--- a/WeatherPlan/WeatherPlan/Domain/UseCase/interface/WeatherInterface.swift
+++ b/WeatherPlan/WeatherPlan/Domain/UseCase/interface/WeatherInterface.swift
@@ -5,9 +5,8 @@
 //  Created by Yunki on 6/16/24.
 //
 
-import WeatherKit
 import CoreLocation.CLLocation
 
 protocol WeatherInterface {
-    func fetchWeather(location: CLLocation) -> [DayWeather]
+    func fetchWeather(location: CLLocation) -> [WeatherModel]
 }


### PR DESCRIPTION
## 개요
- WeatherUseCase 의 Initializer 에서 LocationManager 에 클로저를 넘겨주는 방식으로 분리
- UseCase 와 Manager 사이에 Interface 를 둬서 의존성 분리
- 최종적으로 WeatherUseCase 의 State: [Date: WeatherCondition] 에서 날짜별로 날씨 상태를 불러와서 사용하게 됨
- 데이터 갱신이 필요할 경우는 weatherUseCase.execute(.fetchWeatherData) 로 사용

<!---- Resolves: #3  -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.